### PR TITLE
Add keysend method definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ export interface WebLNProvider {
   /* Prompts the user with a BOLT-11 payment request */
   sendPayment(paymentRequest: string): Promise<SendPaymentResponse>;
 
+  /* Sends a keysend payment to a node without needing an invoice */
+  keysend(args: KeysendArgs): Promise<SendPaymentResponse>;
+
   /* Prompts the user to provide the page with an invoice */
   makeInvoice(amount: string | number | RequestInvoiceArgs): Promise<RequestInvoiceResponse>;
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -24,6 +24,12 @@ export interface RequestInvoiceArgs {
   defaultMemo?: string;
 }
 
+export interface KeysendArgs {
+  destination: string;
+  customRecords: Record<string, string>;
+  amount: string;
+}
+
 export interface RequestInvoiceResponse {
   paymentRequest: string;
 }
@@ -37,6 +43,7 @@ export interface WebLNProvider {
   enable(): Promise<void>;
   getInfo(): Promise<GetInfoResponse>;
   sendPayment(paymentRequest: string): Promise<SendPaymentResponse>;
+  keysend(args: KeysendArgs): Promise<SendPaymentResponse>;
   makeInvoice(args: string | number | RequestInvoiceArgs): Promise<RequestInvoiceResponse>;
   signMessage(message: string): Promise<SignMessageResponse>;
   verifyMessage(signature: string, message: string): Promise<void>;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -26,7 +26,7 @@ export interface RequestInvoiceArgs {
 
 export interface KeysendArgs {
   destination: string;
-  customRecords: Record<string, string>;
+  customRecords?: Record<string, string>;
   amount: string;
 }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -27,7 +27,7 @@ export interface RequestInvoiceArgs {
 export interface KeysendArgs {
   destination: string;
   customRecords?: Record<string, string>;
-  amount: string;
+  amount: string | number;
 }
 
 export interface RequestInvoiceResponse {


### PR DESCRIPTION
Closes #33
We have recently added [keysend support](https://github.com/getAlby/lightning-browser-extension/pull/699) in the Alby extension. We also added webLN methods for this. 

I have to admit I was totally unaware of the discussion here around keysend up until some minutes ago. This is how we implemented it in Alby, if there are obvious flaws in the interface that we decided on we could patch them later.

**Parameters**
- destination: Mandatory. Hex encoded public key of the destination node. This is a string of length 66 that starts either with 02 or 03.
- amount: Mandatory. The amount of satoshis you want to send as a stringified integer.
- customRecords: Mandatory. A map<string, string> of records that are appended to the payment. The key should be a stringified integer from the [TLV Registry](https://github.com/satoshisstream/satoshis.stream/blob/main/TLV_registry.md). The value should be an unencoded, plain string. The webLN provider should handle the encoding if necessary. If no custom records are needed, an empty object must be passed in.

This PR supersedes https://github.com/joule-labs/webln/pull/34, but it is quite similar. We have added support for custom TLV records to be passed in, because this is needed for podcasting 2.0 web apps.