### PR TITLE
Add CI for building package

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,25 @@
+name: Build package
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+      - name: Install dependencies
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: Package
+        run: npm pack
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: webln
+          path: "*.tgz"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,6 +39,9 @@ export default [
           unsafe_comps: true,
           warnings: false,
         },
+        format: {
+          comments: false,
+        },
       }),
     ],
   },


### PR DESCRIPTION
Runs typescript build and exports the npm package. Doesn't do publishing for now.